### PR TITLE
ci: pin versions of actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
       CI: true
 
     steps:
-      - uses: actions/checkout@v3
-      
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
+
       - name: use node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # ratchet:actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-          
+
       - name: run tests
         run: yarn test

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: backstage/actions/cron@v0.6.2
+      - uses: backstage/actions/cron@140a9d5d2fcdb2c97aa7c435bf67834a9fb42bc9 # ratchet:backstage/actions/cron@v0.6.2
         with:
           app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}
           private-key: ${{ secrets.BACKSTAGE_GOALIE_PRIVATE_KEY }}

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -9,4 +9,4 @@ jobs:
 
     steps:
       - name: Sync Issues
-        uses: backstage/actions/issue-sync@v0.6.2
+        uses: backstage/actions/issue-sync@140a9d5d2fcdb2c97aa7c435bf67834a9fb42bc9 # ratchet:backstage/actions/issue-sync@v0.6.2

--- a/.github/workflows/pr-review-comment-trigger.yaml
+++ b/.github/workflows/pr-review-comment-trigger.yaml
@@ -12,7 +12,7 @@ jobs:
     # PR for re-review if this workflow did not fail.
     if: github.event.comment.user.id == github.event.pull_request.user.id
 
-      # Inspired by https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
+    # Inspired by https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
     steps:
       - name: Save PR number
         env:
@@ -20,7 +20,7 @@ jobs:
         run: |
           mkdir -p ./pr
           echo $PR_NUMBER > ./pr/pr_number
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # ratchet:actions/upload-artifact@v3
         with:
           name: pr_number-${{ github.event.pull_request.number }}
           path: pr/

--- a/.github/workflows/pr-review-comment.yaml
+++ b/.github/workflows/pr-review-comment.yaml
@@ -16,7 +16,7 @@ jobs:
       # Inspired by https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
       - name: Read PR Number
         id: pr-number
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # ratchet:actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -33,7 +33,7 @@ jobs:
             const prNumber = artifact.name.slice('pr_number-'.length)
             core.setOutput('pr-number', prNumber);
 
-      - uses: backstage/actions/re-review@v0.6.2
+      - uses: backstage/actions/re-review@140a9d5d2fcdb2c97aa7c435bf67834a9fb42bc9 # ratchet:backstage/actions/re-review@v0.6.2
         with:
           app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}
           private-key: ${{ secrets.BACKSTAGE_GOALIE_PRIVATE_KEY }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,7 +18,7 @@ jobs:
     if: ${{ github.event.pull_request || github.event.issue.pull_request }}
 
     steps:
-      - uses: backstage/actions/pr-sync@v0.6.2
+      - uses: backstage/actions/pr-sync@140a9d5d2fcdb2c97aa7c435bf67834a9fb42bc9 # ratchet:backstage/actions/pr-sync@v0.6.2
         with:
           github-token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN  }}
           app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}


### PR DESCRIPTION
This automatically generated pull request upgrades the workflows using ratchet. It pins the versions of the actions used in the workflows to prevent bad actors from overwriting tags/versions. Please review the changes and merge if everything looks good.